### PR TITLE
Apply zoom to selected category when the PlaceMapState updates.

### DIFF
--- a/place_tracker/lib/place_map.dart
+++ b/place_tracker/lib/place_map.dart
@@ -75,7 +75,21 @@ class PlaceMapState extends State<PlaceMap> {
     });
 
     // Zoom to fit the initially selected category.
-    await _zoomToFitPlaces(
+    _zoomToFitSelectedCategory();
+  }
+
+  @override
+  void didUpdateWidget(PlaceMap oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Zoom to fit the selected category.
+    if (mounted) {
+      _zoomToFitSelectedCategory();
+    }
+  }
+
+  /// Applies zoom to fit the places of the selected category
+  void _zoomToFitSelectedCategory() {
+    _zoomToFitPlaces(
       _getPlacesForCategory(
         Provider.of<AppState>(context, listen: false).selectedCategory,
         _markedPlaces.values.toList(),


### PR DESCRIPTION
This fixes a grey screen issue in web, after saving a place and coming back to the map, the map doesn't remember its boundaries (it seems it gets wildly resized internally). This refreshes the correct zoom-and-boundaries.